### PR TITLE
Fix for 'ELAN29E2:00 04F3:29E2' touchscreen not being recognized

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -157,6 +157,10 @@ function makePointingDevice(pointingDeviceLines) {
         pointingDevice.name = pointingDeviceLines[1].split('"')[1];
         pointingDevice.phys = pointingDeviceLines[2].split('=')[1];
         pointingDevice.type = 'mouse'; //default
+	//Dirty fix for ELAN Touchscreen which is present in some DELL models (e.g. XPS 9500, Precision 5500)
+    	if (pointingDevice.name == 'ELAN29E2:00 04F3:29E2'){
+ 		pointingDevice.name = pointingDevice.name.concat(" Touchscreen");
+    	}
         for (let type in ALL_TYPES) {
             if (ALL_TYPES[type].some((t) => {
                 return (pointingDevice.name.toLowerCase().indexOf(t) >= 0);

--- a/xinput.js
+++ b/xinput.js
@@ -97,6 +97,10 @@ var XInput = class XInput {
         let pointingDevice = {};
         let id = pointingDeviceLine.split('id=')[1].split('\t')[0];
         let name = Lib.executeCmdSync(`xinput --list --name-only ${id}`)[1];
+        //Dirty fix for ELAN Touchscreen which is present in some DELL models (e.g. XPS 9500, Precision 5500)
+        if (name == 'ELAN29E2:00 04F3:29E2'){
+ 		name = name.concat(" Touchscreen");
+    	}
         for (let type in Lib.ALL_TYPES) {
             if (Lib.ALL_TYPES[type].some((t) => {
                 return (name.toLowerCase().indexOf(t) >= 0);


### PR DESCRIPTION
My touchscreen was not correctly recognized so i tried to fix it in some way, `xinput list <id>` below
```
ELAN29E2:00 04F3:29E2                   	id=15	[slave  pointer  (2)]
	Reporting 6 classes:
		Class originated from: 15. Type: XIButtonClass
		Buttons supported: 7
		Button labels: "Button Left" "Button Middle" "Button Right" "Button Wheel Up" "Button Wheel Down" "Button Horiz Wheel Left" "Button Horiz Wheel Right"
		Button state:
		Class originated from: 15. Type: XIValuatorClass
		Detail for Valuator 0:
		  Label: Abs MT Position X
		  Range: 0.000000 - 65535.000000
		  Resolution: 0 units/m
		  Mode: absolute
		  Current value: 60041.550884
		Class originated from: 15. Type: XIValuatorClass
		Detail for Valuator 1:
		  Label: Abs MT Position Y
		  Range: 0.000000 - 65535.000000
		  Resolution: 0 units/m
		  Mode: absolute
		  Current value: 6352.472393
		Class originated from: 15. Type: XIValuatorClass
		Detail for Valuator 2:
		  Label: Rel Horiz Scroll
		  Range: -1.000000 - -1.000000
		  Resolution: 0 units/m
		  Mode: relative
		Class originated from: 15. Type: XIValuatorClass
		Detail for Valuator 3:
		  Label: Rel Vert Scroll
		  Range: -1.000000 - -1.000000
		  Resolution: 0 units/m
		  Mode: relative
		Class originated from: 15. Type: XITouchClass
		Touch mode: direct
		Max number of touches: 10
```
Relevant `cat /proc/bus/input/devices`
```
I: Bus=0018 Vendor=04f3 Product=29e2 Version=0100
N: Name="ELAN29E2:00 04F3:29E2"
P: Phys=i2c-ELAN29E2:00
S: Sysfs=/devices/pci0000:00/0000:00:15.0/i2c_designware.0/i2c-0/i2c-ELAN29E2:00/0018:04F3:29E2.0003/input/input20
U: Uniq=
H: Handlers=mouse2 event10 
B: PROP=2
B: EV=1b
B: KEY=400 0 0 0 0 0
B: ABS=3273800000000003
B: MSC=20

I: Bus=0018 Vendor=04f3 Product=29e2 Version=0100
N: Name="ELAN29E2:00 04F3:29E2 UNKNOWN"
P: Phys=i2c-ELAN29E2:00
S: Sysfs=/devices/pci0000:00/0000:00:15.0/i2c_designware.0/i2c-0/i2c-ELAN29E2:00/0018:04F3:29E2.0003/input/input21
U: Uniq=
H: Handlers=event13 
B: PROP=0
B: EV=9
B: ABS=10000000000

I: Bus=0018 Vendor=04f3 Product=29e2 Version=0100
N: Name="ELAN29E2:00 04F3:29E2 UNKNOWN"
P: Phys=i2c-ELAN29E2:00
S: Sysfs=/devices/pci0000:00/0000:00:15.0/i2c_designware.0/i2c-0/i2c-ELAN29E2:00/0018:04F3:29E2.0003/input/input22
U: Uniq=
H: Handlers=event14 
B: PROP=0
B: EV=100001
```
I made a _dirty_ fix that appends " Touchscreen" to "ELAN29E2:00 04F3:29E2".

Feel free to reject the request if you consider the fix unfit for the project, I'm not fluent at all in JS :)